### PR TITLE
chore(docs): MkDocs Material + CI (#35)

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,28 @@
+name: MkDocs
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install MkDocs
+        run: pip install -r requirements-docs.txt
+
+      - name: Build site
+        run: python -m mkdocs build

--- a/docs/docker-local.md
+++ b/docs/docker-local.md
@@ -60,4 +60,4 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 
 ## Пример переменных окружения
 
-Файл с плейсхолдерами (без реальных ключей): **[`docker/local.example.env`](../docker/local.example.env)**. Имена переменных с префиксом `ZCH_LOCAL_*` не подхватываются Compose автоматически — это ориентир для приложений и скриптов на хосте.
+Файл с плейсхолдерами (без реальных ключей): **[`docker/local.example.env`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docker/local.example.env)** (в репозитории, вне каталога `docs/`). Имена переменных с префиксом `ZCH_LOCAL_*` не подхватываются Compose автоматически — это ориентир для приложений и скриптов на хосте.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -99,6 +99,7 @@ git commit -m "chore(submodule): bump <name> after #12"
 
 ## Скрипты в репозитории
 
+- `mkdocs.yml`, `requirements-docs.txt` — статический сайт из каталога `docs/` (Material for MkDocs): `pip install -r requirements-docs.txt`, затем `mkdocs serve` или `mkdocs build` (см. [index.md](index.md)).
 - `scripts/sync-openapi-snapshot.ps1` — сохраняет `GET /api/openapi.json` с запущенного сервиса в `docs/openapi/snapshots/` (см. [openapi-sync.md](openapi-sync.md)).
 - `scripts/bootstrap-dev-branches.ps1` — создаёт/обновляет ветку `dev` во всех субмодулях от `master`.
 - `scripts/gh-create-issues.ps1` — создаёт стартовый набор issues через GitHub CLI (`gh`), **идемпотентность не гарантируется** (повторный запуск создаст дубликаты). Запускать один раз после установки `gh auth login`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# Документация ZhuchkaKeyboards
+
+Монорепозиторий: субмодули сервисов, Docker Compose для локальной инфраструктуры, обзорные материалы в каталоге `docs/`.
+
+## Быстрые ссылки
+
+| Тема | Документ |
+|------|----------|
+| Ветки, PR, субмодули | [git-workflow.md](git-workflow.md) |
+| Список субмодулей | [submodules.md](submodules.md) |
+| Docker, Traefik, MinIO (локально) | [docker-local.md](docker-local.md) |
+| OpenAPI и снимки API | [openapi-sync.md](openapi-sync.md) |
+| Требования к HTTP/API | [microservices-api-requirements.md](microservices-api-requirements.md) |
+| Описание микросервисов | [microservices/README.md](microservices/README.md) |
+
+Полный список страниц — в навигации слева и через поиск (иконка в шапке).
+
+## Сборка сайта
+
+Из корня репозитория:
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve   # предпросмотр на http://127.0.0.1:8000
+# mkdocs build  # статика в ./site (каталог в .gitignore)
+```

--- a/docs/openapi-sync.md
+++ b/docs/openapi-sync.md
@@ -35,7 +35,7 @@
 
 ## Где лежат снимки
 
-Каталог [`openapi/snapshots/`](openapi/snapshots/) — согласованное место для файлов `*.openapi.json`; см. [README](openapi/snapshots/README.md) внутри каталога.
+Каталог `docs/openapi/snapshots/` — согласованное место для файлов `*.openapi.json`; см. [README](openapi/snapshots/README.md).
 
 ## Автоматизация
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+# MkDocs: статическая документация из каталога docs/
+# См. docs/index.md и requirements-docs.txt
+
+site_name: ZhuchkaKeyboards
+site_description: Монорепозиторий — документация
+repo_url: https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards
+edit_uri: edit/dev/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: ru
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+plugins:
+  - search:
+      lang:
+        - ru
+        - en
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Главная: index.md
+  - Git:
+      - git-workflow.md
+      - submodules.md
+  - Локальная разработка:
+      - docker-local.md
+      - openapi-sync.md
+      - "Снимки OpenAPI": openapi/snapshots/README.md
+  - Архитектура:
+      - architecture-and-domain-thoughts.md
+      - microservices-fine-split.md
+      - database-tables-plan.md
+  - Требования:
+      - microservices-api-requirements.md
+      - frontend-requirements.md
+  - Микросервисы:
+      - Обзор: microservices/README.md
+      - "01 Auth": microservices/01-auth.md
+      - "02 Directory": microservices/02-directory.md
+      - "03 Catalog": microservices/03-catalog.md
+      - "04 Commerce": microservices/04-commerce.md
+      - "05 Payments": microservices/05-payments.md
+      - "06 OMS": microservices/06-oms.md
+      - "07 Fulfillment": microservices/07-fulfillment.md
+      - "08 Inventory": microservices/08-inventory.md
+      - "09 WMS": microservices/09-wms.md
+      - "10 Production": microservices/10-production.md
+      - "11 Custom": microservices/11-custom.md
+      - "12 Procurement": microservices/12-procurement.md
+      - "13 Counterparties": microservices/13-counterparties.md
+      - "14 Notification": microservices/14-notification.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+# MkDocs (monorepo root only). Install: pip install -r requirements-docs.txt
+# MkDocs 2.x пока не совместим с Material; держим линию 1.x
+mkdocs>=1.6.1,<2
+mkdocs-material>=9.5,<10


### PR DESCRIPTION
Adds [mkdocs.yml](mkdocs.yml), [requirements-docs.txt](requirements-docs.txt), [docs/index.md](docs/index.md), workflow [.github/workflows/mkdocs.yml](.github/workflows/mkdocs.yml). Material theme, ru/en search, full microservices nav.

- Link fix for \docker/local.example.env\ (GitHub blob) and \openapi/snapshots\ README in nav.
- Git workflow: note about \mkdocs serve\ / \mkdocs build\.

Closes #35

Made with [Cursor](https://cursor.com)