### PR TITLE
feat(docker): catalog service behind Traefik (#33)

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,11 +1,13 @@
-# Overlay: auth-service behind Traefik (Host auth.localhost) + direct port 8000 for debugging.
-# Prerequisite: add to hosts — 127.0.0.1 auth.localhost
+# Overlay: auth + catalog behind Traefik + direct host ports for debugging.
+# Prerequisite: add to hosts — 127.0.0.1 auth.localhost catalog.localhost
 #
 # Usage (from monorepo root):
 #   docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 #
-# Open: http://auth.localhost:8080/.well-known/openid-configuration
-# Direct (bypass Traefik): set ISSUER to http://localhost:8000 in a copied config if needed.
+# Open:
+#   http://auth.localhost:8080/.well-known/openid-configuration
+#   http://catalog.localhost:8080/api/openapi.json
+# Direct (bypass Traefik): auth :8000, catalog :8001
 
 services:
   auth:
@@ -24,3 +26,24 @@ services:
       - "traefik.http.routers.auth.rule=Host(`auth.localhost`)"
       - "traefik.http.routers.auth.entrypoints=web"
       - "traefik.http.services.auth.loadbalancer.server.port=8000"
+
+  catalog:
+    build:
+      context: ./services/catalog
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ./docker/catalog/config.dev.ini:/app/config.ini:ro
+      - ./docker/catalog/alembic.ini:/app/alembic.ini:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    command: ["sh", "-c", "alembic upgrade head && exec python src/main.py"]
+    ports:
+      - "8001:8000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.catalog.rule=Host(`catalog.localhost`)"
+      - "traefik.http.routers.catalog.entrypoints=web"
+      - "traefik.http.services.catalog.loadbalancer.server.port=8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@
 # Buckets keyboards + parts are created by minio-init (ignore-existing on re-runs).
 # DB/cache images: Debian Trixie–based official builds (pinned versions).
 # If you upgrade from an older major Postgres image, remove volume zhuchka_pgdata or run pg_upgrade.
+# docker/postgres/docker-entrypoint-initdb.d/*.sql run only on first init (empty data dir).
 
 services:
   postgres:
@@ -18,6 +19,7 @@ services:
       - "5432:5432"
     volumes:
       - zhuchka_pgdata:/var/lib/postgresql/data
+      - ./docker/postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U zhuchka -d zhuchka_auth"]
       interval: 5s

--- a/docker/catalog/alembic.ini
+++ b/docker/catalog/alembic.ini
@@ -1,0 +1,46 @@
+# Alembic for local Docker — URL matches docker/catalog/config.dev.ini
+# Copy of services/catalog/alembic.ini.example with sqlalchemy.url for Docker network.
+
+[alembic]
+script_location = src/database/alembic
+prepend_sys_path = .
+version_path_separator = os
+output_encoding = utf-8
+
+sqlalchemy.url = postgresql+asyncpg://zhuchka:zhuchka@postgres:5432/zhuchka_catalog
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/docker/catalog/config.dev.ini
+++ b/docker/catalog/config.dev.ini
@@ -1,0 +1,30 @@
+# Local Docker Compose — catalog service. Weak credentials; not for production.
+# Mounted as /app/config.ini for services/catalog container.
+
+[POSTGRES]
+DATABASE = postgresql
+DRIVER = asyncpg
+DATABASE_NAME = zhuchka_catalog
+USERNAME = zhuchka
+PASSWORD = zhuchka
+IP = postgres
+PORT = 5432
+DATABASE_ENGINE_POOL_TIMEOUT = 30
+DATABASE_ENGINE_POOL_RECYCLE = 3600
+DATABASE_ENGINE_POOL_SIZE = 5
+DATABASE_ENGINE_MAX_OVERFLOW = 10
+DATABASE_ENGINE_POOL_PING = true
+DATABASE_ECHO = false
+
+[UVICORN]
+HOST = 0.0.0.0
+PORT = 8000
+WORKERS = 1
+LOOP = asyncio
+HTTP = auto
+
+[REDIS]
+HOST = redis
+PORT = 6379
+DB = 0
+PASSWORD =

--- a/docker/postgres/docker-entrypoint-initdb.d/02-zhuchka-catalog.sql
+++ b/docker/postgres/docker-entrypoint-initdb.d/02-zhuchka-catalog.sql
@@ -1,0 +1,3 @@
+-- Runs only on first initialization of the Postgres data directory (new volume).
+-- Extra database for services/catalog in local compose overlay.
+CREATE DATABASE zhuchka_catalog OWNER zhuchka;

--- a/docs/docker-local.md
+++ b/docs/docker-local.md
@@ -1,6 +1,6 @@
 # Локальный Docker-стек (корень монорепозитория)
 
-Файлы в корне: **`docker-compose.yml`** (Postgres, Redis, MinIO, Traefik) и **`docker-compose.local.yml`** (оверлей: сервис **auth** за Traefik и прямой порт для отладки).
+Файлы в корне: **`docker-compose.yml`** (Postgres, Redis, MinIO, Traefik) и **`docker-compose.local.yml`** (оверлей: сервисы **auth** и **catalog** за Traefik и прямые порты для отладки).
 
 Запуск из корня:
 
@@ -14,6 +14,7 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 
 ```text
 127.0.0.1 auth.localhost
+127.0.0.1 catalog.localhost
 ```
 
 ## Traefik
@@ -28,17 +29,21 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 | Хост (на порту хоста `8080`) | Router (имя в labels) | Сервис Compose | Порт контейнера бэкенда |
 |------------------------------|------------------------|----------------|-------------------------|
 | `auth.localhost` | `auth` | `auth` | `8000` |
+| `catalog.localhost` | `catalog` | `catalog` | `8000` |
 
-Соответствующие labels в `docker-compose.local.yml` (сводка):
-
-- `traefik.enable=true`
-- `traefik.http.routers.auth.rule=Host(\`auth.localhost\`)`
-- `traefik.http.routers.auth.entrypoints=web`
-- `traefik.http.services.auth.loadbalancer.server.port=8000`
+Соответствующие labels в `docker-compose.local.yml` (сводка): для каждого сервиса — `traefik.enable=true`, `Host(\`<имя>.localhost\`)`, `entrypoints=web`, `loadbalancer.server.port=8000`.
 
 Проверка OIDC: `http://auth.localhost:8080/.well-known/openid-configuration`.
 
-Остальные сервисы стека пока **не** публикуются через Traefik; при появлении новых сервисов с labels таблицу следует дополнить.
+OpenAPI каталога: `http://catalog.localhost:8080/api/openapi.json`.
+
+### База `zhuchka_catalog`
+
+При **первом** создании тома Postgres скрипт `docker/postgres/docker-entrypoint-initdb.d/02-zhuchka-catalog.sql` создаёт БД `zhuchka_catalog`. Если том **`zhuchka_pgdata` уже существовал** без этой базы, выполните один раз:
+
+```bash
+docker compose -f docker-compose.yml exec postgres psql -U zhuchka -d zhuchka_auth -c "CREATE DATABASE zhuchka_catalog OWNER zhuchka;"
+```
 
 ## Прямые порты (минуя Traefik)
 
@@ -51,8 +56,9 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 | `9000` | `minio` | S3 API |
 | `9001` | `minio` | веб-консоль MinIO |
 | `8000` | `auth` | HTTP auth (оверлей; тот же сервис, что за Traefik) |
+| `8001` | `catalog` | HTTP catalog (оверлей) |
 
-Из других контейнеров в той же сети Compose имена хостов: `postgres`, `redis`, `minio`, `auth` (см. `docker-compose.yml` / оверлей).
+Из других контейнеров в той же сети Compose имена хостов: `postgres`, `redis`, `minio`, `auth`, `catalog` (см. `docker-compose.yml` / оверлей).
 
 ## MinIO
 


### PR DESCRIPTION
## Summary
- **Postgres:** mount \docker/postgres/docker-entrypoint-initdb.d\ — creates \zhuchka_catalog\ on first init; doc for manual \CREATE DATABASE\ if volume already existed.
- **Overlay:** \catalog\ service (build \services/catalog\), \catalog.localhost\ via Traefik, host \:8001\, \lembic upgrade head\ then app; configs in \docker/catalog/\.
- **docs/docker-local.md:** hosts, Traefik table, ports.

Refs #33

Made with [Cursor](https://cursor.com)