### PR TITLE
feat(docker): payments service behind Traefik (#33)

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,5 +1,5 @@
-# Overlay: auth + catalog + commerce behind Traefik + direct host ports for debugging.
-# Prerequisite: add to hosts — 127.0.0.1 auth.localhost catalog.localhost commerce.localhost
+# Overlay: auth + catalog + commerce + payments behind Traefik + direct host ports for debugging.
+# Prerequisite: add to hosts — 127.0.0.1 auth.localhost catalog.localhost commerce.localhost payments.localhost
 #
 # Usage (from monorepo root):
 #   docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
@@ -8,7 +8,8 @@
 #   http://auth.localhost:8080/.well-known/openid-configuration
 #   http://catalog.localhost:8080/api/openapi.json
 #   http://commerce.localhost:8080/api/openapi.json
-# Direct (bypass Traefik): auth :8000, catalog :8001, commerce :8002
+#   http://payments.localhost:8080/api/openapi.json
+# Direct (bypass Traefik): auth :8000, catalog :8001, commerce :8002, payments :8003
 
 services:
   auth:
@@ -69,3 +70,24 @@ services:
       - "traefik.http.routers.commerce.rule=Host(`commerce.localhost`)"
       - "traefik.http.routers.commerce.entrypoints=web"
       - "traefik.http.services.commerce.loadbalancer.server.port=8000"
+
+  payments:
+    build:
+      context: ./services/payments
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ./docker/payments/config.dev.ini:/app/config.ini:ro
+      - ./docker/payments/alembic.ini:/app/alembic.ini:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    command: ["sh", "-c", "alembic upgrade head && exec python src/main.py"]
+    ports:
+      - "8003:8000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.payments.rule=Host(`payments.localhost`)"
+      - "traefik.http.routers.payments.entrypoints=web"
+      - "traefik.http.services.payments.loadbalancer.server.port=8000"

--- a/docker/payments/alembic.ini
+++ b/docker/payments/alembic.ini
@@ -1,0 +1,45 @@
+# Alembic for local Docker — URL matches docker/payments/config.dev.ini
+
+[alembic]
+script_location = src/database/alembic
+prepend_sys_path = .
+version_path_separator = os
+output_encoding = utf-8
+
+sqlalchemy.url = postgresql+asyncpg://zhuchka:zhuchka@postgres:5432/zhuchka_payments
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/docker/payments/config.dev.ini
+++ b/docker/payments/config.dev.ini
@@ -1,0 +1,30 @@
+# Local Docker Compose — payments service. Weak credentials; not for production.
+# Mounted as /app/config.ini for services/payments container.
+
+[POSTGRES]
+DATABASE = postgresql
+DRIVER = asyncpg
+DATABASE_NAME = zhuchka_payments
+USERNAME = zhuchka
+PASSWORD = zhuchka
+IP = postgres
+PORT = 5432
+DATABASE_ENGINE_POOL_TIMEOUT = 30
+DATABASE_ENGINE_POOL_RECYCLE = 3600
+DATABASE_ENGINE_POOL_SIZE = 5
+DATABASE_ENGINE_MAX_OVERFLOW = 10
+DATABASE_ENGINE_POOL_PING = true
+DATABASE_ECHO = false
+
+[UVICORN]
+HOST = 0.0.0.0
+PORT = 8000
+WORKERS = 1
+LOOP = asyncio
+HTTP = auto
+
+[REDIS]
+HOST = redis
+PORT = 6379
+DB = 0
+PASSWORD =

--- a/docker/postgres/docker-entrypoint-initdb.d/04-zhuchka-payments.sql
+++ b/docker/postgres/docker-entrypoint-initdb.d/04-zhuchka-payments.sql
@@ -1,0 +1,3 @@
+-- Runs only on first initialization of the Postgres data directory (new volume).
+-- Extra database for services/payments in local compose overlay.
+CREATE DATABASE zhuchka_payments OWNER zhuchka;

--- a/docs/architecture-and-domain-thoughts.md
+++ b/docs/architecture-and-domain-thoughts.md
@@ -61,7 +61,7 @@
 ### 0.2 Входной трафик — Traefik
 
 - **Traefik** как **reverse proxy / ingress**: TLS (Let’s Encrypt), маршрутизация по хостам и путям, health checks, опционально rate limit на уровне маршрутов.
-- **Локальная разработка (монорепо):** в `docker-compose.yml` поднят Traefik; оверлей `docker-compose.local.yml` публикует за ним **Auth**, **Catalog** и **Commerce** по хостам `auth.localhost`, `catalog.localhost`, `commerce.localhost` (вход HTTP на хосте `8080`). Таблица маршрутов, `hosts` и прямые порты — в [`docker-local.md`](docker-local.md).
+- **Локальная разработка (монорепо):** в `docker-compose.yml` поднят Traefik; оверлей `docker-compose.local.yml` публикует за ним **Auth**, **Catalog**, **Commerce** и **Payments** по хостам `auth.localhost`, `catalog.localhost`, `commerce.localhost`, `payments.localhost` (вход HTTP на хосте `8080`). Таблица маршрутов, `hosts` и прямые порты — в [`docker-local.md`](docker-local.md).
 - Типичная **продакшен-**раскладка (цель):
   - `www` / основной домен → **публичный фронт**;
   - `admin` / `app` или путь `/admin` → **операционный фронт** (защита сетью + авторизацией);

--- a/docs/docker-local.md
+++ b/docs/docker-local.md
@@ -1,6 +1,6 @@
 # Локальный Docker-стек (корень монорепозитория)
 
-Файлы в корне: **`docker-compose.yml`** (Postgres, Redis, MinIO, Traefik) и **`docker-compose.local.yml`** (оверлей: сервисы **auth**, **catalog** и **commerce** за Traefik и прямые порты для отладки).
+Файлы в корне: **`docker-compose.yml`** (Postgres, Redis, MinIO, Traefik) и **`docker-compose.local.yml`** (оверлей: **auth**, **catalog**, **commerce**, **payments** за Traefik и прямые порты для отладки).
 
 Запуск из корня:
 
@@ -16,6 +16,7 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 127.0.0.1 auth.localhost
 127.0.0.1 catalog.localhost
 127.0.0.1 commerce.localhost
+127.0.0.1 payments.localhost
 ```
 
 ## Traefik
@@ -32,12 +33,13 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 | `auth.localhost` | `auth` | `auth` | `8000` |
 | `catalog.localhost` | `catalog` | `catalog` | `8000` |
 | `commerce.localhost` | `commerce` | `commerce` | `8000` |
+| `payments.localhost` | `payments` | `payments` | `8000` |
 
 Соответствующие labels в `docker-compose.local.yml` (сводка): для каждого сервиса — `traefik.enable=true`, `Host(\`<имя>.localhost\`)`, `entrypoints=web`, `loadbalancer.server.port=8000`.
 
 Проверка OIDC: `http://auth.localhost:8080/.well-known/openid-configuration`.
 
-OpenAPI: `http://catalog.localhost:8080/api/openapi.json`, `http://commerce.localhost:8080/api/openapi.json`.
+OpenAPI (примеры): `http://catalog.localhost:8080/api/openapi.json`, `http://commerce.localhost:8080/api/openapi.json`, `http://payments.localhost:8080/api/openapi.json`.
 
 ### База `zhuchka_catalog`
 
@@ -55,6 +57,14 @@ docker compose -f docker-compose.yml exec postgres psql -U zhuchka -d zhuchka_au
 docker compose -f docker-compose.yml exec postgres psql -U zhuchka -d zhuchka_auth -c "CREATE DATABASE zhuchka_commerce OWNER zhuchka;"
 ```
 
+### База `zhuchka_payments`
+
+При первом init тома выполняется `04-zhuchka-payments.sql`. Если базы не было:
+
+```bash
+docker compose -f docker-compose.yml exec postgres psql -U zhuchka -d zhuchka_auth -c "CREATE DATABASE zhuchka_payments OWNER zhuchka;"
+```
+
 ## Прямые порты (минуя Traefik)
 
 Удобно для клиентов на хосте (IDE, CLI) и для отладки без Host-заголовка.
@@ -68,8 +78,9 @@ docker compose -f docker-compose.yml exec postgres psql -U zhuchka -d zhuchka_au
 | `8000` | `auth` | HTTP auth (оверлей; тот же сервис, что за Traefik) |
 | `8001` | `catalog` | HTTP catalog (оверлей) |
 | `8002` | `commerce` | HTTP commerce (оверлей) |
+| `8003` | `payments` | HTTP payments (оверлей) |
 
-Из других контейнеров в той же сети Compose имена хостов: `postgres`, `redis`, `minio`, `auth`, `catalog`, `commerce` (см. `docker-compose.yml` / оверлей).
+Из других контейнеров в той же сети Compose имена хостов: `postgres`, `redis`, `minio`, `auth`, `catalog`, `commerce`, `payments` (см. `docker-compose.yml` / оверлей).
 
 ## MinIO
 


### PR DESCRIPTION
Adds \zhuchka_payments\, \docker/payments/*\, Traefik \payments.localhost\, host port 8003; docs + architecture §0.2.

Refs #33

Made with [Cursor](https://cursor.com)